### PR TITLE
added timeout option on requests

### DIFF
--- a/pypdns/api.py
+++ b/pypdns/api.py
@@ -47,11 +47,11 @@ class PyPDNS(object):
             proxy = {'https': https_proxy_string}
             self.session.proxies.update(proxy)
 
-    def query(self, q: str, sort_by: str='time_last') -> List[Dict]:
+    def query(self, q: str, sort_by: str = 'time_last', timeout: int = None) -> List[Dict]:
         logger.info("start query() q=[%s]", q)
         if sort_by not in sort_choice:
             raise PDNSError('You can only sort by ' + ', '.join(sort_choice))
-        response = self.session.get('{}/{}' .format(self.url, q))
+        response = self.session.get('{}/{}' .format(self.url, q), timeout=timeout)
         if response.status_code != 200:
             self._handle_http_error(response)
         to_return = []


### PR DESCRIPTION
Hi everyone, I am the maintainer of [IntelOwl](https://github.com/intelowlproject/IntelOwl) that uses this library.

Recently I noticed that there is no chance to set up a timeout on requests to the servers. This is important to avoid long waitings.

If you please merge this little addition and make a new release, I'll leverage the changes in IntelOwl.

thank you in advance