### PR TITLE
Initialized named logger

### DIFF
--- a/pypdns/api.py
+++ b/pypdns/api.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     HAS_CACHE = False
 import logging
-logger = logging
+logger = logging.getLogger("pypdns")
 
 sort_choice = ['count', 'rdata', 'rrname', 'rrtype', 'time_first', 'time_last']
 


### PR DESCRIPTION
Initialized a named logger instead of using the root logger. This is to improve the interoperability of the library when used alongside other libraries. 

#7 