### PR TITLE
Using UTC timezone for `time_first` & `time_last` datetime values

### DIFF
--- a/pypdns/api.py
+++ b/pypdns/api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 
-from datetime import datetime
+from datetime import datetime, timezone
 from importlib.metadata import version
 from typing import Any, TypedDict, overload, Literal, Generator
 
@@ -189,14 +189,14 @@ class PDNSRecord:
         '''The first time that the record / unique tuple (rrname, rrtype, rdata)
            has been seen by the passive DNS, as a python datetime.
         '''
-        return datetime.fromtimestamp(self.time_first)
+        return datetime.fromtimestamp(self.time_first, timezone.utc)
 
     @property
     def time_last_datetime(self) -> datetime:
         '''The last time that the record / unique tuple (rrname, rrtype, rdata)
            has been seen by the passive DNS, as a python datetime.
         '''
-        return datetime.fromtimestamp(self.time_last)
+        return datetime.fromtimestamp(self.time_last, timezone.utc)
 
     @property
     def count(self) -> int | None:
@@ -428,8 +428,8 @@ class PyPDNS:
         '''
         records, errors = self._query(q, sort_by)
         for record in records:
-            record['time_first'] = datetime.fromtimestamp(record['time_first'])  # type: ignore
-            record['time_last'] = datetime.fromtimestamp(record['time_last'])  # type: ignore
+            record['time_first'] = datetime.fromtimestamp(record['time_first'], timezone.utc)  # type: ignore
+            record['time_last'] = datetime.fromtimestamp(record['time_last'], timezone.utc)  # type: ignore
         return records
 
     def _handle_dribble_errors(self, response: requests.Response) -> dict[str, str | int]:


### PR DESCRIPTION
The recorded values for those fields are UTC timestamps.

I discovered the UTC timezone was not specified while playing with the [Passive DNS MISP module](https://github.com/MISP/misp-modules/blob/59c994678da633d55ce79056d80186198ed82ad7/misp_modules/modules/expansion/circl_passivedns.py#L61), where I had different values **displayed** - and displayed only - between the `first_seen` field of the MISP object and the `time_first` attribute - same with respectively `last_seen` and `time_last` attribute -  even though it is the same value that is used.

It is not as bad as I first thought it was in my case though, as MISP interprets datetime values with no specific timezone as UTC by default, and I had the timestamps converted into the right UTC datetime values in the final result on MISP Events/Attributes/Objects.  
But I would still set the UTC timezone to avoid issue with third party services or scripts querying MISP modules and potentially parsing the results before pushing them to MISP.

This is only the MISP integration point of view, but I don't think it should break any code using pypdns, as the fields that are concerned by the change still have the exact same datetime format, the only difference is the timezone parameter.  
Let me know if you see any blocker